### PR TITLE
fix(tf-helpers): handle offline mode and linting without GitHub auth

### DIFF
--- a/dsb-tf-proj-helpers.sh
+++ b/dsb-tf-proj-helpers.sh
@@ -82,35 +82,23 @@ unsetFunctionsWithPrefix() {
   local prefix="${1}"
   local functionNames
   local cutCmd
-  local mvCmd
 
   # MacOS: GNU commands mapping
   if [[ $(uname -m) == "arm64" ]]; then
     cutCmd="gcut"
-    mvCmd="gmv"
   fi
   # ARM64 Linux
   if [[ $(uname -m) == "aarch64" ]] && [[ $(uname -s) == "Linux" ]]; then
     cutCmd="cut"
-    mvCmd="mv"
   fi
   # x86_64 Linux
   if [[ $(uname -m) == "x86_64" ]] && [[ $(uname -s) == "Linux" ]]; then
     cutCmd="cut"
-    mvCmd="mv"
   fi
 
   # run just if cut command is set
   if [ -n "${cutCmd}" ]; then
     functionNames=$(declare -F | grep -e " ${prefix}" | "${cutCmd}" --fields 3 --delimiter=' ') || functionNames=''
-    for functionName in ${functionNames}; do
-      unset -f "${functionName}" || :
-    done
-  fi
-
-  # run just if mv command is set
-  if [ -n "${mvCmd}" ]; then
-    functionNames=$(declare -F | grep -e " ${prefix}" | "${mvCmd}" --fields 3 --delimiter=' ') || functionNames=''
     for functionName in ${functionNames}; do
       unset -f "${functionName}" || :
     done

--- a/dsb-tf-proj-helpers.sh
+++ b/dsb-tf-proj-helpers.sh
@@ -4547,6 +4547,7 @@ _dsb_tf_install_tflint_wrapper() {
   local wrapperDir="${_dsbTfTflintWrapperDir:-}"
   local wrapperPath="${_dsbTfTflintWrapperPath:-}"
   local wrapperApiUrl="/repos/dsb-norge/terraform-tflint-wrappers/contents/tflint_linux.sh"
+  local wrapperPublicUrl="https://raw.githubusercontent.com/dsb-norge/terraform-tflint-wrappers/main/tflint_linux.sh"
 
   if [ -z "${wrapperDir}" ] || [ -z "${wrapperPath}" ]; then
     _dsb_e "Internal error: expected to find tflint wrapper directory and path."
@@ -4568,7 +4569,24 @@ _dsb_tf_install_tflint_wrapper() {
   _dsb_d "  from: ${wrapperApiUrl}"
   _dsb_d "  to: ${wrapperPath}"
 
-  gh api -H 'Accept: application/vnd.github.v3.raw' "${wrapperApiUrl}" >"${wrapperPath}"
+  if _dsbTfLogErrors=0 _dsb_tf_check_gh_cli; then
+    _dsb_d "trying with GitHub CLI"
+    if ! gh api -H 'Accept: application/vnd.github.v3.raw' "${wrapperApiUrl}" 2>/dev/null >"${wrapperPath}"; then
+      _dsb_d "failed using GitHub CLI, trying with curl and public URL"
+
+      if ! curl -sSL -o "${wrapperPath}" "${wrapperPublicUrl}"; then
+        _dsb_d "curl also failed"
+        return 1
+      fi
+    fi
+  else
+    _dsb_d "GitHub CLI not available, trying with curl and public URL"
+
+    if ! curl -sSL -o "${wrapperPath}" "${wrapperPublicUrl}"; then
+      _dsb_d "curl fails"
+      return 1
+    fi
+  fi
 
   return 0
 }
@@ -4586,6 +4604,7 @@ _dsb_tf_run_tflint() {
   local selectedEnv="${1:-${_dsbTfSelectedEnv:-}}"
   shift || :
   local lintArguments="$*"
+  local githubAuthAvailable=1 # assume available until proven otherwise
 
   _dsb_d "called with:"
   _dsb_d " - selectedEnv: ${selectedEnv}"
@@ -4598,9 +4617,9 @@ _dsb_tf_run_tflint() {
   fi
 
   # check that gh cli is installed and user is logged in
-  if ! _dsb_tf_check_gh_auth; then
-    _dsbTfReturnCode=1
-    return 0
+  if ! _dsbTfLogErrors=0 _dsb_tf_check_gh_auth; then
+    _dsb_d "GitHub authentication unavailable, proceeding without GitHub authentication"
+    githubAuthAvailable=0
   fi
 
   # leverage _dsb_tf_set_env, this enumerates directories and validates the environment
@@ -4613,6 +4632,7 @@ _dsb_tf_run_tflint() {
   fi
 
   # make sure tflint is installed
+  #   function falls back to using curl if gh cli fails, ie. if not authenticated with GitHub
   if ! _dsbTfLogErrors=0 _dsb_tf_install_tflint_wrapper; then
     _dsb_e "Failed to install tflint wrapper, consider enabling debug logging"
     _dsbTfReturnCode=1
@@ -4635,10 +4655,15 @@ _dsb_tf_run_tflint() {
 
   # get GitHub API token
   local ghToken
-  if ! ghToken=$(gh auth token); then
-    _dsb_e "Failed to get GitHub API token."
-    _dsbTfReturnCode=1
-    return 0
+  if [ "${githubAuthAvailable}" -ne 1 ]; then
+    _dsb_d "GitHub authentication unavailable, proceeding without API token"
+    ghToken=""
+  else
+    _dsb_d "GitHub authentication available, attempting to get API token"
+    if ! ghToken=$(gh auth token 2>/dev/null); then
+      _dsb_w "Failed to get GitHub API token even though authentication is available, attempting to proceed without API token"
+      ghToken=""
+    fi
   fi
 
   # invoke the tflint wrapper script

--- a/dsb-tf-proj-helpers.sh
+++ b/dsb-tf-proj-helpers.sh
@@ -4439,7 +4439,7 @@ _dsb_tf_plan_env() {
 
   # output from the command will have paths relative to the current environment directory
   #   pipe all output (stdout and stderr) to _dsb_tf_fixup_paths_from_stdin to make they are relative to the root directory
-  if ! terraform -chdir="${envDir}" plan 2>&1 | _dsb_tf_fixup_paths_from_stdin; then
+  if ! terraform -chdir="${envDir}" plan -lock=false 2>&1 | _dsb_tf_fixup_paths_from_stdin; then
     _dsb_e "terraform plan in ./$(_dsb_tf_get_rel_dir "${envDir:-}") failed"
     _dsbTfReturnCode=1
   else

--- a/dsb-tf-proj-helpers.sh
+++ b/dsb-tf-proj-helpers.sh
@@ -3890,7 +3890,7 @@ _dsb_tf_init_env_actual() {
 
   # output from the command will have paths relative to the current environment directory
   #   pipe all output (stdout and stderr) to _dsb_tf_fixup_paths_from_stdin to make they are relative to the root directory
-  if ! terraform -chdir="${envDir}" init -reconfigure ${extraInitArgs} 2>&1 | _dsb_tf_fixup_paths_from_stdin; then
+  if ! terraform -chdir="${envDir}" init -reconfigure -lock=false ${extraInitArgs} 2>&1 | _dsb_tf_fixup_paths_from_stdin; then
     _dsb_d "terraform init failed, attempting to restore tfstate file ... "
 
     if [ -f "${localStateFileOld}" ]; then

--- a/dsb-tf-proj-helpers.sh
+++ b/dsb-tf-proj-helpers.sh
@@ -2855,6 +2855,11 @@ _dsb_tf_look_for_environment_file() {
   local suppliedGlobalToSavePathTo="${3:-}"
   local selectedEnv selectedEnvDir lookForFilename
 
+  _dsb_d "called with:"
+  _dsb_d "  suppliedEnv: ${suppliedEnv}"
+  _dsb_d "  suppliedFileType: ${suppliedFileType}"
+  _dsb_d "  suppliedGlobalToSavePathTo: ${suppliedGlobalToSavePathTo}"
+
   case "${suppliedFileType}" in
   "lock")
     lookForFilename=".terraform.lock.hcl"
@@ -3770,14 +3775,19 @@ _dsb_tf_az_select_sub() {
 #   sets the subscription to the selected environment
 # input:
 #   $1: environment name
+#   $2: if we are in offline mode (optional, defaults to 0)
+#         ie. do not expect to be able to resolve subscription name to id
 # on info:
 #   nothing
 # returns:
 #   exit code in _dsbTfReturnCode
 _dsb_tf_terraform_preflight() {
   local selectedEnv="${1}"
+  local offlineInit="${2:-0}" # defaults to 0
 
-  _dsb_d "called with: selectedEnv=${selectedEnv}"
+  _dsb_d "called with:"
+  _dsb_d "  selectedEnv: ${selectedEnv}"
+  _dsb_d "  offlineInit: ${offlineInit}"
 
   if [ -z "${selectedEnv}" ]; then
     _dsb_e "No environment selected, please run 'tf-select-env' or 'tf-set-env <env>'"
@@ -3809,19 +3819,23 @@ _dsb_tf_terraform_preflight() {
     return 1
   fi
 
-  # should be set when _dsb_tf_set_env was successful
+  # subscription should be set when _dsb_tf_set_env was successful and we are not offline
   local subId="${_dsbTfSubscriptionId:-}"
-  if [ -z "${subId}" ]; then
+  if [ -z "${subId}" ] && [ "${offlineInit}" -eq 0 ]; then
     _dsb_d "unset ARM_SUBSCRIPTION_ID"
     unset ARM_SUBSCRIPTION_ID
     _dsb_internal_error "Internal error: expected to find subscription ID." \
       "  expected in: _dsbTfSubscriptionId"
     return 1
+  elif [ "${offlineInit}" -eq 1 ]; then
+    _dsb_d "offline mode, setting ARM_SUBSCRIPTION_ID to empty string"
+    export ARM_SUBSCRIPTION_ID=""
   else
     # required by azurerm terraform provider
     export ARM_SUBSCRIPTION_ID="${subId}"
-    _dsb_d "exported ARM_SUBSCRIPTION_ID: ${ARM_SUBSCRIPTION_ID}"
   fi
+
+  _dsb_d "current ARM_SUBSCRIPTION_ID: '${ARM_SUBSCRIPTION_ID}'"
 
   return 0
 }
@@ -3847,11 +3861,12 @@ _dsb_tf_init_env_actual() {
   local localStateFile="${envDir}/.terraform/terraform.tfstate"
   local localStateFileOld="${envDir}/.terraform/terraform.tfstate.tf-helpers-old"
 
-  _dsb_d "doUpgrade: ${doUpgrade}"
-  _dsb_d "offlineInit: ${offlineInit}"
-  _dsb_d "envDir: ${envDir}"
-  _dsb_d "subId: ${subId}"
-  _dsb_d "current ARM_SUBSCRIPTION_ID: ${ARM_SUBSCRIPTION_ID}"
+  _dsb_d "called with:"
+  _dsb_d "  doUpgrade: ${doUpgrade}"
+  _dsb_d "  offlineInit: ${offlineInit}"
+  _dsb_d "  envDir: ${envDir}"
+  _dsb_d "  subId: ${subId}"
+  _dsb_d "  current ARM_SUBSCRIPTION_ID: '${ARM_SUBSCRIPTION_ID}'"
 
   if [ "${doUpgrade}" -eq 1 ]; then
     extraInitArgs=" -upgrade"
@@ -3934,7 +3949,7 @@ _dsb_tf_init_env() {
   _dsb_d "  offlineInit: ${offlineInit}"
   _dsb_d "  selectedEnv: ${selectedEnv}"
 
-  if ! _dsb_tf_terraform_preflight "${selectedEnv}"; then
+  if ! _dsb_tf_terraform_preflight "${selectedEnv}" "${offlineInit}"; then
     _dsbTfReturnCode=1
     _dsb_d "_dsb_tf_terraform_preflight failed with non-zero exit code"
     _dsb_d "  _dsbTfReturnCode: ${_dsbTfReturnCode}"
@@ -4193,7 +4208,7 @@ _dsb_tf_init() {
     _dsb_i ""
 
     # preflight, check if terraform is installed, set the environment and check if it is valid
-    if ! _dsb_tf_terraform_preflight "${envName}"; then
+    if ! _dsb_tf_terraform_preflight "${envName}" "${offlineInit}"; then
       _dsb_d "_dsb_tf_terraform_preflight failed with non-zero exit code"
       _dsb_d "  _dsbTfReturnCode: ${_dsbTfReturnCode}"
       _dsb_e "  preflight checks failed for ${envName}"
@@ -4269,9 +4284,10 @@ _dsb_tf_init_full_single_env() {
   local offlineInit="${2:-0}" # defaults to 0
   local envToInit="${3:-}"    # defaults to empty string
 
-  _dsb_d "doUpgrade: ${doUpgrade}"
-  _dsb_d "envToInit: ${envToInit}"
-  _dsb_d "offlineInit: ${offlineInit}"
+  _dsb_d "called with:"
+  _dsb_d "  doUpgrade: ${doUpgrade}"
+  _dsb_d "  envToInit: ${envToInit}"
+  _dsb_d "  offlineInit: ${offlineInit}"
 
   declare -g _dsbTfReturnCode=0 # default return code
 
@@ -4361,7 +4377,8 @@ _dsb_tf_fmt() {
 _dsb_tf_validate_env() {
   local selectedEnv="${1:-${_dsbTfSelectedEnv:-}}"
 
-  if ! _dsb_tf_terraform_preflight "${selectedEnv}"; then
+  # we always do preflight in offline mode since no subscription resolution is needed for validate
+  if ! _dsb_tf_terraform_preflight "${selectedEnv}" 1; then # $2 = 1 means offline init
     _dsbTfReturnCode=1
     _dsb_d "_dsb_tf_terraform_preflight failed with non-zero exit code"
     _dsb_d "  _dsbTfReturnCode: ${_dsbTfReturnCode}"
@@ -4376,7 +4393,7 @@ _dsb_tf_validate_env() {
   _dsb_i ""
   _dsb_i "Validating environment: $(_dsb_tf_get_rel_dir "${envDir}")"
 
-  _dsb_d "current ARM_SUBSCRIPTION_ID: ${ARM_SUBSCRIPTION_ID}"
+  _dsb_d "current ARM_SUBSCRIPTION_ID: '${ARM_SUBSCRIPTION_ID}'"
 
   # output from the command will have paths relative to the current environment directory
   #   pipe all output (stdout and stderr) to _dsb_tf_fixup_paths_from_stdin to make they are relative to the root directory
@@ -4418,7 +4435,7 @@ _dsb_tf_plan_env() {
   _dsb_i ""
   _dsb_i "Creating plan for environment: $(_dsb_tf_get_rel_dir "${envDir}")"
 
-  _dsb_d "current ARM_SUBSCRIPTION_ID: ${ARM_SUBSCRIPTION_ID}"
+  _dsb_d "current ARM_SUBSCRIPTION_ID: '${ARM_SUBSCRIPTION_ID}'"
 
   # output from the command will have paths relative to the current environment directory
   #   pipe all output (stdout and stderr) to _dsb_tf_fixup_paths_from_stdin to make they are relative to the root directory
@@ -4460,7 +4477,7 @@ _dsb_tf_apply_env() {
   _dsb_i ""
   _dsb_i "Running apply in environment: $(_dsb_tf_get_rel_dir "${envDir}")"
 
-  _dsb_d "current ARM_SUBSCRIPTION_ID: ${ARM_SUBSCRIPTION_ID}"
+  _dsb_d "current ARM_SUBSCRIPTION_ID: '${ARM_SUBSCRIPTION_ID}'"
 
   # output from the command will have paths relative to the current environment directory
   if ! terraform -chdir="${envDir}" apply; then
@@ -4497,7 +4514,7 @@ _dsb_tf_destroy_env() {
     return 0
   fi
 
-  _dsb_d "current ARM_SUBSCRIPTION_ID: ${ARM_SUBSCRIPTION_ID}"
+  _dsb_d "current ARM_SUBSCRIPTION_ID: '${ARM_SUBSCRIPTION_ID}'"
 
   local envDir="${_dsbTfSelectedEnvDir}"
   _dsb_i ""


### PR DESCRIPTION
# changes

Improve handling of offline mode by allowing operations without a subscription ID. Support linting when GitHub authentication is unavailable. Ensure that initialization and planning operations do not lock the state.

## commits

- chore(tf-helpers): plan operation should not lock state
- chore(tf-helpers): init operation should not lock state
- feat(tf-helpers): support linting when github auth is not available
- fix(tf-helpers): offline mode, handle no subscription id available
